### PR TITLE
Introduction of a simple inventory holder

### DIFF
--- a/bobstats/inventories/common.py
+++ b/bobstats/inventories/common.py
@@ -33,6 +33,9 @@ class UniswapLikeInventoryStats(BaseModel):
 class BobVaultInventoryStats(BaseModel):
     token0: BaseInventoryStats
 
+class InventoryHolderStats(BaseModel):
+    token0: BaseInventoryStats
+
 class UniswapLikePositionsManager:
     postions: List[Position] = []
     fee_denominator: int = 0

--- a/bobstats/inventories/holder.py
+++ b/bobstats/inventories/holder.py
@@ -1,0 +1,49 @@
+from typing import Dict
+from decimal import Decimal
+
+from web3 import Web3
+
+from utils.web3 import Web3Provider, ERC20Token
+from utils.settings.models import InventoryHolder
+from utils.constants import BOB_TOKEN_ADDRESS
+from utils.logging import info, error
+
+from .common import BaseInventoryStats, InventoryHandler, InventoryHolderStats
+
+class InventoryHolderHandler(InventoryHandler):
+    w3prov: Web3
+    holder_addr: str
+
+    def __init__(
+        self,
+        w3_provider: Web3Provider,
+        holder_addr: str
+    ):
+        self.w3prov = w3_provider
+        self.holder_addr = holder_addr
+
+    @classmethod
+    def generate_handler(cls, w3: Web3Provider, params: InventoryHolder):
+        holder_addr = Web3.toChecksumAddress(params.address)
+        return cls(w3, holder_addr)
+
+    def get_stats(self) -> Dict[str, InventoryHolderStats]:
+        info(f'{self.w3prov.chainid}: getting info for Holder')
+        inventory_stats = {}
+
+        bobtoken = ERC20Token(self.w3prov, BOB_TOKEN_ADDRESS)
+        try:
+            tvl = bobtoken.balanceOf(self.holder_addr)
+        except:
+            error(f'{self.w3prov.chainid}: not able to get data')
+        else:
+            info(f'{self.w3prov.chainid}: tvl: {tvl}')
+            inventory_stats[f'BOB_on_{self.holder_addr[:6]}'] = InventoryHolderStats(
+                token0 = BaseInventoryStats(
+                    symbol = bobtoken.symbol(),
+                    tvl = tvl,
+                    fees = Decimal(0)
+                )
+            )
+
+        return inventory_stats

--- a/bobstats/inventory.py
+++ b/bobstats/inventory.py
@@ -12,6 +12,7 @@ from .inventories.common import InventoryHandler, UniswapLikeInventoryStats, Bob
 from .inventories.uniswap import UniswapInventoryHandler
 from .inventories.kyberswap import KyberswapElasticInventoryHandler
 from .inventories.bobvault import BobVaultInventoryHandler
+from .inventories.holder import InventoryHolderHandler
 
 class Inventory:
     _w3_providers: Dict[str, Web3Provider]
@@ -20,7 +21,8 @@ class Inventory:
 
     _inventory_protocols = {'UniswapV3': UniswapInventoryHandler,
                             'KyberSwap Elastic': KyberswapElasticInventoryHandler,
-                            'BobVault': BobVaultInventoryHandler
+                            'BobVault': BobVaultInventoryHandler,
+                            'Holder': InventoryHolderHandler
                            }
 
     def __init__(self, settings: Settings):

--- a/token-deployments-info.json.example
+++ b/token-deployments-info.json.example
@@ -19,6 +19,10 @@
           "address":"0x61a57F1C82DA40e632C075D7812Af375Db23367c",
           "start_block":"26230002",
           "feeding_service_path":"/bsc/upload"
+        },
+        {
+          "protocol":"Holder",
+          "address":"0x525b4E120dDC602fF055Aa86803acD7D71F0c753"
         }
       ],
       "token":{

--- a/utils/settings/models.py
+++ b/utils/settings/models.py
@@ -20,6 +20,10 @@ class BobVaultInventory(BaseModel):
     start_block: int
     feeding_service_path: str
 
+class InventoryHolder(BaseModel):
+    protocol: str
+    address: str
+
 class CoinGeckoMarkets(BaseModel):
     known: Optional[List[str]]
     exclude: Optional[List[str]]
@@ -30,6 +34,5 @@ class DepoloymentDescriptor(BaseModel):
     events_pull_interval: int
     rpc: RPCSpec
     token: TokenSpec
-    inventories: Optional[List[Union[UniswapLikeInventory, BobVaultInventory]]]
+    inventories: Optional[List[Union[UniswapLikeInventory, BobVaultInventory, InventoryHolder]]]
     coingecko: Optional[CoinGeckoMarkets]
-


### PR DESCRIPTION
This is required to reflect inventory held by interim accounts like the inventory minters in [GP10](https://docs.zkbob.com/bob-stablecoin/bob-governance-and-inventory/protocol-governance/gp-10-reallocate-previous-kyberswap-inventory)